### PR TITLE
fix(avatar): border must show background

### DIFF
--- a/.changeset/quick-plants-cheat.md
+++ b/.changeset/quick-plants-cheat.md
@@ -1,0 +1,7 @@
+---
+"@qualcomm-ui/qds-core": patch
+---
+
+fix(avatar): show background through status indicator border
+
+commit: e624e92

--- a/packages/common/qds-core/src/avatar/qds-avatar.css
+++ b/packages/common/qds-core/src/avatar/qds-avatar.css
@@ -18,6 +18,8 @@
     --avatar-size: 24px;
     --avatar-content-font: var(--font-static-heading-xxs-bold);
     --avatar-status-size: 6px;
+    --avatar-status-border-size: var(--icon-stroke-xs);
+    --avatar-status-offset: 0px;
     & .qui-icon__root {
       --icon-size: 16px;
     }
@@ -26,6 +28,8 @@
     --avatar-size: 32px;
     --avatar-content-font: var(--font-static-heading-xs-bold);
     --avatar-status-size: 8px;
+    --avatar-status-border-size: var(--icon-stroke-sm);
+    --avatar-status-offset: 1px;
     & .qui-icon__root {
       --icon-size: 20px;
     }
@@ -35,6 +39,8 @@
     --avatar-size: 48px;
     --avatar-content-font: var(--font-static-heading-md-bold);
     --avatar-status-size: 12px;
+    --avatar-status-border-size: var(--icon-stroke-md);
+    --avatar-status-offset: 1px;
     & .qui-icon__root {
       --icon-size: 24px;
     }
@@ -43,6 +49,8 @@
     --avatar-size: 56px;
     --avatar-content-font: var(--font-static-heading-lg-bold);
     --avatar-status-size: 16px;
+    --avatar-status-border-size: var(--icon-stroke-lg);
+    --avatar-status-offset: 1px;
     & .qui-icon__root {
       --icon-size: 32px;
     }
@@ -51,8 +59,32 @@
     --avatar-size: 80px;
     --avatar-content-font: var(--font-static-heading-xl);
     --avatar-status-size: 20px;
+    --avatar-status-border-size: var(--icon-stroke-xl);
+    --avatar-status-offset: 2px;
     & .qui-icon__root {
       --icon-size: 40px;
+    }
+  }
+
+  &:has(.qui-avatar__status) {
+    --_status-cutout-offset: calc(
+      var(--avatar-status-offset) + var(--avatar-status-size) / 2
+    );
+    --_status-cutout-x: calc(100% - var(--_status-cutout-offset));
+    --_status-cutout-y: calc(100% - var(--_status-cutout-offset));
+    --_status-cutout-radius: calc(
+      var(--avatar-status-size) / 2 + var(--avatar-status-border-size)
+    );
+
+    /* the "border" around status needs to show the background
+       this is achieved with a mask and a 1px gradient at its edge to avoid aliasing */
+    & > .qui-avatar__image,
+    & > .qui-avatar__content {
+      mask-image: radial-gradient(
+        circle at var(--_status-cutout-x) var(--_status-cutout-y),
+        transparent calc(var(--_status-cutout-radius) - 0.5px),
+        black calc(var(--_status-cutout-radius) + 0.5px)
+      );
     }
   }
 }
@@ -104,19 +136,12 @@
 }
 
 .qui-avatar__status {
-  border: var(--avatar-status-border-size, 1px) solid
-    var(--color-border-neutral-00);
   border-radius: 50%;
-  bottom: 0;
-  box-sizing: border-box;
+  bottom: var(--avatar-status-offset);
   height: var(--avatar-status-size);
   position: absolute;
-  right: 0;
+  right: var(--avatar-status-offset);
   width: var(--avatar-status-size);
-
-  :is([data-size="lg"], [data-size="xl"]) & {
-    --avatar-status-border-size: 2px;
-  }
 
   &[data-status="active"] {
     background-color: var(--color-background-support-success);

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/_avatar.mdx
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/_avatar.mdx
@@ -45,7 +45,7 @@ placeholder
 broken image
 :::
 
-The `q-avatar-content` directive displays alternative content within the avatar. Use it by itself to show initials or an icon, or together with `q-avatar-image` to provide fallback content if the image cannot be loaded.
+The `q-avatar-content` directive displays alternative content within the avatar. Use it by itself to show a single character or an icon, or together with `q-avatar-image` to provide fallback content if the image cannot be loaded.
 
 <QdsDemo name="AvatarContentDemo" className="bg-neutral-03" />
 

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-content-demo.ts
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-content-demo.ts
@@ -14,7 +14,7 @@ import {provideIcons} from "@qualcomm-ui/angular-core/lucide"
       <!-- preview -->
       Initials
       <div q-avatar>
-        <div q-avatar-content>OK</div>
+        <div q-avatar-content>O</div>
       </div>
       Icon
       <div q-avatar>
@@ -25,7 +25,7 @@ import {provideIcons} from "@qualcomm-ui/angular-core/lucide"
       Fallback
       <div q-avatar>
         <img alt="John Doe" q-avatar-image src="https://example.invalid" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       <!-- preview -->
     </div>

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-emphasis-demo.ts
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-emphasis-demo.ts
@@ -10,15 +10,15 @@ import {AvatarModule} from "@qualcomm-ui/angular/avatar"
       <!-- preview -->
       Neutral
       <div emphasis="neutral" q-avatar>
-        <div q-avatar-content>OK</div>
+        <div q-avatar-content>O</div>
       </div>
       High Contrast
       <div emphasis="contrast" q-avatar>
-        <div q-avatar-content>OK</div>
+        <div q-avatar-content>O</div>
       </div>
       Brand
       <div emphasis="brand" q-avatar>
-        <div q-avatar-content>OK</div>
+        <div q-avatar-content>O</div>
       </div>
       <!-- preview -->
     </div>

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-showcase-demo.ts
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-showcase-demo.ts
@@ -9,7 +9,7 @@ import {AvatarModule} from "@qualcomm-ui/angular/avatar"
     <!-- preview -->
     <div q-avatar status="active">
       <img alt="John Doe" q-avatar-image src="/images/avatar-man.png" />
-      <div q-avatar-content>JD</div>
+      <div q-avatar-content>J</div>
       <div q-avatar-status></div>
     </div>
     <!-- preview -->

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-size-demo.ts
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-size-demo.ts
@@ -11,27 +11,27 @@ import {AvatarModule} from "@qualcomm-ui/angular/avatar"
       XSmall
       <div q-avatar size="xs">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       Small
       <div q-avatar size="sm">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       Medium
       <div q-avatar size="md">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       Large
       <div q-avatar size="lg">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       XLarge
       <div q-avatar size="xl">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       <!-- preview -->
     </div>

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-state-callback-demo.ts
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-state-callback-demo.ts
@@ -10,12 +10,12 @@ import {AvatarModule} from "@qualcomm-ui/angular/avatar"
       <!-- preview -->
       <div q-avatar (stateChanged)="currentStateValid.set($event.state)">
         <img alt="John Doe" q-avatar-image src="/images/avatar-man.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       <output>current state: {{ currentStateValid() }}</output>
       <div q-avatar (stateChanged)="currentStateInvalid.set($event.state)">
         <img alt="John Doe" q-avatar-image src="https://example.invalid" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
       </div>
       <output>current state: {{ currentStateInvalid() }}</output>
       <!-- preview -->

--- a/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-status-demo.ts
+++ b/packages/docs/angular-docs/src/routes/components+/avatar+/demos/avatar-status-demo.ts
@@ -11,25 +11,25 @@ import {AvatarModule} from "@qualcomm-ui/angular/avatar"
       Active
       <div q-avatar status="active">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
         <div q-avatar-status></div>
       </div>
       Offline
       <div q-avatar status="offline">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
         <div q-avatar-status></div>
       </div>
       Away
       <div q-avatar status="away">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
         <div q-avatar-status></div>
       </div>
       Busy
       <div q-avatar status="busy">
         <img alt="Jane Doe" q-avatar-image src="/images/avatar-woman.png" />
-        <div q-avatar-content>JD</div>
+        <div q-avatar-content>J</div>
         <div q-avatar-status></div>
       </div>
       <!-- preview -->

--- a/packages/docs/react-docs/src/routes/components+/avatar+/_avatar.mdx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/_avatar.mdx
@@ -46,7 +46,7 @@ placeholder
 broken image
 :::
 
-The `Avatar.Content` component displays alternative content within the avatar. Use it by itself to show initials or an icon, or together with `Avatar.Image` to provide fallback content if the image cannot be loaded.
+The `Avatar.Content` component displays alternative content within the avatar. Use it by itself to show a single character or an icon, or together with `Avatar.Image` to provide fallback content if the image cannot be loaded.
 
 <Demo name="AvatarContentDemo" component={demos.AvatarContentDemo} />
 

--- a/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-content-demo.tsx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-content-demo.tsx
@@ -10,7 +10,7 @@ export function AvatarContentDemo(): ReactElement {
       {/* preview */}
       Initials
       <Avatar.Root>
-        <Avatar.Content>OK</Avatar.Content>
+        <Avatar.Content>O</Avatar.Content>
       </Avatar.Root>
       Icon
       <Avatar.Root>
@@ -19,7 +19,7 @@ export function AvatarContentDemo(): ReactElement {
       Fallback
       <Avatar.Root>
         <Avatar.Image alt="John Doe" src="https://example.invalid" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
       </Avatar.Root>
       {/* preview */}
     </div>

--- a/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-emphasis-demo.tsx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-emphasis-demo.tsx
@@ -8,15 +8,15 @@ export function AvatarEmphasisDemo(): ReactElement {
       {/* preview */}
       Neutral
       <Avatar.Root emphasis="neutral">
-        <Avatar.Content>OK</Avatar.Content>
+        <Avatar.Content>O</Avatar.Content>
       </Avatar.Root>
       High Contrast
       <Avatar.Root emphasis="contrast">
-        <Avatar.Content>OK</Avatar.Content>
+        <Avatar.Content>O</Avatar.Content>
       </Avatar.Root>
       Brand
       <Avatar.Root emphasis="brand">
-        <Avatar.Content>OK</Avatar.Content>
+        <Avatar.Content>O</Avatar.Content>
       </Avatar.Root>
       {/* preview */}
     </div>

--- a/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-showcase-demo.tsx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-showcase-demo.tsx
@@ -7,7 +7,7 @@ export function AvatarShowcaseDemo(): ReactElement {
     // preview
     <Avatar.Root status="active">
       <Avatar.Image alt="John Doe" src="/images/avatar-man.png" />
-      <Avatar.Content>JD</Avatar.Content>
+      <Avatar.Content>J</Avatar.Content>
       <Avatar.Status />
     </Avatar.Root>
     // preview

--- a/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-size-demo.tsx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-size-demo.tsx
@@ -13,7 +13,7 @@ export function AvatarSizeDemo(): ReactElement {
         <div key={size} className="flex flex-col items-center gap-2">
           <Avatar.Root size={size}>
             <Avatar.Image alt="Jane Doe" src="/images/avatar-woman.png" />
-            <Avatar.Content>JD</Avatar.Content>
+            <Avatar.Content>J</Avatar.Content>
           </Avatar.Root>
           {size}
         </div>

--- a/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-state-callback-demo.tsx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-state-callback-demo.tsx
@@ -14,14 +14,14 @@ export function AvatarStateCallbackDemo(): ReactElement {
       {/* preview */}
       <Avatar.Root onStateChange={(event) => setCurrentStateValid(event.state)}>
         <Avatar.Image alt="John Doe" src="/images/avatar-man.png" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
       </Avatar.Root>
       <output>current state: {currentStateValid}</output>
       <Avatar.Root
         onStateChange={(event) => setCurrentStateInvalid(event.state)}
       >
         <Avatar.Image alt="John Doe" src="https://example.invalid" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
       </Avatar.Root>
       <output>current state: {currentStateInvalid}</output>
       {/* preview */}

--- a/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-status-demo.tsx
+++ b/packages/docs/react-docs/src/routes/components+/avatar+/demos/avatar-status-demo.tsx
@@ -9,25 +9,25 @@ export function AvatarStatusDemo(): ReactElement {
       Active
       <Avatar.Root status="active">
         <Avatar.Image alt="Jane Doe" src="/images/avatar-woman.png" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
         <Avatar.Status />
       </Avatar.Root>
       Offline
       <Avatar.Root status="offline">
         <Avatar.Image alt="Jane Doe" src="/images/avatar-woman.png" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
         <Avatar.Status />
       </Avatar.Root>
       Away
       <Avatar.Root status="away">
         <Avatar.Image alt="Jane Doe" src="/images/avatar-woman.png" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
         <Avatar.Status />
       </Avatar.Root>
       Busy
       <Avatar.Root status="busy">
         <Avatar.Image alt="Jane Doe" src="/images/avatar-woman.png" />
-        <Avatar.Content>JD</Avatar.Content>
+        <Avatar.Content>J</Avatar.Content>
         <Avatar.Status />
       </Avatar.Root>
       {/* preview */}


### PR DESCRIPTION
- the "border" around the status indicator now is a mask to let the background show
- updated doc to only use one letter in "initial" use case