### PR TITLE
fix(select): a11y + keyboard nav fixes

### DIFF
--- a/.changeset/fancy-items-find.md
+++ b/.changeset/fancy-items-find.md
@@ -1,0 +1,8 @@
+---
+"@qualcomm-ui/core": patch
+"@qualcomm-ui/dom": patch
+---
+
+fix(focus-visible): support focusVisible option in programmatic focus
+
+commit: d605803

--- a/.changeset/hip-ducks-float.md
+++ b/.changeset/hip-ducks-float.md
@@ -1,0 +1,10 @@
+---
+"@qualcomm-ui/core": patch
+"@qualcomm-ui/qds-core": patch
+"@qualcomm-ui/react": patch
+"@qualcomm-ui/angular": patch
+---
+
+fix(select): make disclosure indicator inert
+
+commit: 012754b

--- a/.changeset/tricky-hounds-ring.md
+++ b/.changeset/tricky-hounds-ring.md
@@ -1,0 +1,7 @@
+---
+"@qualcomm-ui/core": patch
+---
+
+fix(select): allow keyboard interaction on clear button
+
+commit: c238b9a

--- a/.claude/skills/conventional-commit-rebaser/SKILL.md
+++ b/.claude/skills/conventional-commit-rebaser/SKILL.md
@@ -38,6 +38,7 @@ Format: `<type>(<scope>): <description>`
 - Scope optional, lowercase
 - Max 72 chars for subject line
 - Breaking changes: append `!` before colon (e.g. `feat(api)!: change response format`)
+- Describe the intent or user-facing effect, not the code change. Prefer "allow keyboard interaction on clear button" over "ignore keyboard events from child elements". Fall back to describing the mechanism only when the change is purely internal with no observable behavior change (e.g. a refactor).
 - Reserve the body for changes that are not described in the message. Never use prose or paragraphs that repeat the commit message.
 
 ## Procedure

--- a/packages/common/core/src/select/select.api.ts
+++ b/packages/common/core/src/select/select.api.ts
@@ -290,6 +290,9 @@ export function createSelectApi(
           if (!interactive) {
             return
           }
+          if (event.target !== event.currentTarget) {
+            return
+          }
 
           const keyMap: EventKeyMap = {
             ArrowDown(event) {

--- a/packages/common/core/src/select/select.api.ts
+++ b/packages/common/core/src/select/select.api.ts
@@ -421,6 +421,7 @@ export function createSelectApi(
         "data-scope": "select",
         "data-state": open ? "open" : "closed",
         dir: prop("dir"),
+        inert: true,
         tabIndex: -1,
       })
     },

--- a/packages/common/core/src/select/select.machine.ts
+++ b/packages/common/core/src/select/select.machine.ts
@@ -6,7 +6,7 @@
 
 import {trackDismissableElement} from "@qualcomm-ui/dom/dismissable"
 import {getPlacement, type Placement} from "@qualcomm-ui/dom/floating-ui"
-import {trackFocusVisible} from "@qualcomm-ui/dom/focus-visible"
+import {isFocusVisible, trackFocusVisible} from "@qualcomm-ui/dom/focus-visible"
 import {
   getByTypeahead,
   getInitialFocus,
@@ -290,7 +290,7 @@ export const selectMachine: MachineConfig<SelectSchema> =
           const element = getInitialFocus({
             root: domEls.content(scope),
           })
-          element?.focus({preventScroll: true})
+          element?.focus({focusVisible: isFocusVisible(), preventScroll: true})
         })
       },
 

--- a/packages/common/core/src/select/select.types.ts
+++ b/packages/common/core/src/select/select.types.ts
@@ -526,6 +526,7 @@ export interface SelectIndicatorBindings extends CommonBindings {
   "data-part": "indicator"
   "data-readonly": BooleanDataAttr
   "data-state": "open" | "closed"
+  inert: true
   tabIndex: -1
 }
 

--- a/packages/common/dom/src/focus-visible/focus-visible.ts
+++ b/packages/common/dom/src/focus-visible/focus-visible.ts
@@ -16,6 +16,12 @@ import {
   isMac,
 } from "@qualcomm-ui/dom/query"
 
+declare global {
+  interface FocusOptions {
+    focusVisible?: boolean
+  }
+}
+
 function isVirtualClick(event: MouseEvent | PointerEvent): boolean {
   if ((event as any).mozInputSource === 0 && event.isTrusted) {
     return true
@@ -184,12 +190,14 @@ function setupGlobalFocusEvents(root?: RootNode) {
   const doc = getDocument(root)
 
   const focus = win.HTMLElement.prototype.focus
-  win.HTMLElement.prototype.focus = function () {
+  win.HTMLElement.prototype.focus = function (options?: FocusOptions) {
     // For programmatic focus, we remove the focus visible state to prevent showing
-    // focus rings When `options.focusVisible` is supported in most browsers, we can
-    // remove this @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible
-    currentModality = "virtual"
-    triggerChangeHandlers("virtual", null)
+    // focus rings. Call sites can opt back in by passing `focusVisible: true`.
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible
+    if (options?.focusVisible !== true) {
+      currentModality = "virtual"
+      triggerChangeHandlers("virtual", null)
+    }
 
     hasEventBeforeFocus = true
     focus.apply(

--- a/packages/common/qds-core/src/select/qds-select.css
+++ b/packages/common/qds-core/src/select/qds-select.css
@@ -84,8 +84,7 @@
 
   &[data-state="open"],
   &:focus,
-  &:focus-visible,
-  &:focus-within {
+  &:focus-visible {
     border-color: var(--color-utility-focus-border);
     outline: 1px solid var(--color-utility-focus-border);
   }

--- a/packages/frameworks/react/src/select/select-indicator.tsx
+++ b/packages/frameworks/react/src/select/select-indicator.tsx
@@ -23,7 +23,7 @@ export interface SelectIndicatorProps extends ElementRenderProp<"button"> {
 
 /**
  * Icon that indicates the open/close state of the select's associated panel.
- * Renders a `<div>` element by default.
+ * Renders a `<button>` element by default.
  */
 export function SelectIndicator({
   icon = ChevronDown,


### PR DESCRIPTION
[`012754b`](https://github.com/qualcomm/qualcomm-ui/pull/166/commits/012754b5f8daec2390cd7a68f874ee349f333e03) a11y: adds `inert` to the disclosure indicator (as is the initial intent) and prevents this warning when users click on it:
<img width="535" height="206" alt="image" src="https://github.com/user-attachments/assets/952fa078-5b52-4f5f-b30e-b6aca6564c4d" />

[`d605803`](https://github.com/qualcomm/qualcomm-ui/pull/166/commits/d605803f5361ad1f303f65059d4d3889fe50e321) kbd nav: attempts to fix the fact that the first option does not appear focused when opening a select for the first time (works fine in Angular)

[`c238b9a`](https://github.com/qualcomm/qualcomm-ui/pull/166/commits/c238b9a2e2dfce2ab6a4a38c279274fef5ed9331) kbd nav: fixes the fact that the clear button cannot be interacted with when it has focus

[`9f68528`](https://github.com/qualcomm/qualcomm-ui/pull/166/commits/9f68528197d148d063e4111a2857cc03a3718813) Claude skill update