### PR TITLE
eslint-mdx-deps

### DIFF
--- a/packages/configs/eslint-config-mdx/CHANGELOG.md
+++ b/packages/configs/eslint-config-mdx/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @qualcomm-ui/eslint-config-mdx Changelog
 
+## 2.0.1
+
+Apr 22nd, 2026
+
+### Bug Fixes
+
+- move dependencies to peerDependencies ([a595b84](https://github.com/qualcomm/qualcomm-ui/commit/a595b84))
+
 ## 2.0.0
 
 Apr 21st, 2026

--- a/packages/configs/eslint-config-mdx/package.json
+++ b/packages/configs/eslint-config-mdx/package.json
@@ -32,7 +32,12 @@
     "prepublishOnly": "qui-cli pre-publish",
     "postpublish": "qui-cli post-publish"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@eslint/core": "^1.0.0",
+    "@qualcomm-ui/cli": "catalog:",
+    "eslint-mdx": "^3.7.0",
+    "eslint-plugin-mdx": "^3.7.0",
+    "eslint-plugin-react": "^7.37.5",
     "remark-frontmatter": "^5.0.0",
     "remark-lint-fenced-code-flag": "^4.2.0",
     "remark-lint-final-newline": "^3.0.1",
@@ -43,14 +48,7 @@
     "remark-lint-no-consecutive-blank-lines": "^5.0.1",
     "remark-lint-no-duplicate-headings-in-section": "^4.0.1",
     "remark-lint-no-heading-punctuation": "^4.0.1",
-    "remark-lint-unordered-list-marker-style": "^4.0.1"
-  },
-  "devDependencies": {
-    "@eslint/core": "^1.0.0",
-    "@qualcomm-ui/cli": "catalog:",
-    "eslint-mdx": "^3.7.0",
-    "eslint-plugin-mdx": "^3.7.0",
-    "eslint-plugin-react": "^7.37.5",
+    "remark-lint-unordered-list-marker-style": "^4.0.1",
     "unified": "^11.0.5"
   },
   "peerDependencies": {
@@ -58,6 +56,17 @@
     "eslint-mdx": ">=3.7.0",
     "eslint-plugin-mdx": ">=3.7.0",
     "eslint-plugin-react": ">=7.37.5",
+    "remark-frontmatter": ">=5.0.0",
+    "remark-lint-fenced-code-flag": ">=4.2.0",
+    "remark-lint-final-newline": ">=3.0.1",
+    "remark-lint-heading-increment": ">=4.0.1",
+    "remark-lint-list-item-content-indent": ">=4.0.1",
+    "remark-lint-list-item-indent": ">=4.0.1",
+    "remark-lint-maximum-heading-length": ">=4.1.1",
+    "remark-lint-no-consecutive-blank-lines": ">=5.0.1",
+    "remark-lint-no-duplicate-headings-in-section": ">=4.0.1",
+    "remark-lint-no-heading-punctuation": ">=4.0.1",
+    "remark-lint-unordered-list-marker-style": ">=4.0.1",
     "typescript": ">=5.9.3",
     "typescript-eslint": ">=8.31.1",
     "unified": ">=11"

--- a/packages/configs/eslint-config-mdx/package.json
+++ b/packages/configs/eslint-config-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualcomm-ui/eslint-config-mdx",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "QUI ESLint config for consistent MDX code",
   "author": "Ryan Bower",
   "license": "BSD-3-Clause-Clear",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,6 +995,28 @@ importers:
       eslint:
         specifier: 9.39.1
         version: 9.39.1(jiti@2.6.1)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: '>=8.31.1'
+        version: 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+    devDependencies:
+      '@eslint/core':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@qualcomm-ui/cli':
+        specifier: 'catalog:'
+        version: 1.0.6
+      eslint-mdx:
+        specifier: ^3.7.0
+        version: 3.7.0(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-mdx:
+        specifier: ^3.7.0
+        version: 3.7.0(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       remark-frontmatter:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1028,28 +1050,6 @@ importers:
       remark-lint-unordered-list-marker-style:
         specifier: ^4.0.1
         version: 4.0.1
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
-      typescript-eslint:
-        specifier: '>=8.31.1'
-        version: 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-    devDependencies:
-      '@eslint/core':
-        specifier: ^1.0.0
-        version: 1.0.0
-      '@qualcomm-ui/cli':
-        specifier: 'catalog:'
-        version: 1.0.6
-      eslint-mdx:
-        specifier: ^3.7.0
-        version: 3.7.0(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-mdx:
-        specifier: ^3.7.0
-        version: 3.7.0(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-react:
-        specifier: ^7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       unified:
         specifier: ^11.0.5
         version: 11.0.5


### PR DESCRIPTION
# Release Notes

## @qualcomm-ui/eslint-config-mdx — 2.0.1 (Apr 22nd, 2026)

### Bug Fixes

- move dependencies to peerDependencies ([a595b84](https://github.com/qualcomm/qualcomm-ui/commit/a595b84))
