### PR TITLE
navDensity

### DIFF
--- a/packages/frameworks/react-mdx/CHANGELOG.md
+++ b/packages/frameworks/react-mdx/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @qualcomm-ui/react-mdx Changelog
 
+## 2.6.0
+
+Apr 28th, 2026
+
+### Features
+
+- [docs-layout]: add NavDensity type and prop, defaults to "compact" ([4cd65b5](https://github.com/qualcomm/qualcomm-ui/commit/4cd65b5))
+- [sidebar]: integrate navDensity from context ([9636533](https://github.com/qualcomm/qualcomm-ui/commit/9636533))
+
 ## 2.5.0
 
 Apr 23rd, 2026

--- a/packages/frameworks/react-mdx/package.json
+++ b/packages/frameworks/react-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualcomm-ui/react-mdx",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "React components and utilities for MDX documentation sites based on QUI Docs",
   "author": "Ryan Bower",
   "license": "BSD-3-Clause-Clear",

--- a/packages/frameworks/react-mdx/src/docs-layout/docs-layout.css
+++ b/packages/frameworks/react-mdx/src/docs-layout/docs-layout.css
@@ -133,14 +133,16 @@
     height: 100%;
   }
 
-  /* TODO: remove when the small side nav size lands */
-  .qui-side-nav__node-root {
-    height: 32px;
-    min-height: 32px;
+  &[data-nav-density="compact"] {
+    /* TODO: remove when the small side nav size lands */
+    .qui-side-nav__node-root {
+      height: 32px;
+      min-height: 32px;
 
-    &:has(+ .qui-side-nav__node-root),
-    &:has(+ .qui-side-nav__branch-root) {
-      margin-bottom: 1px;
+      &:has(+ .qui-side-nav__node-root),
+      &:has(+ .qui-side-nav__branch-root) {
+        margin-bottom: 1px;
+      }
     }
   }
 

--- a/packages/frameworks/react-mdx/src/docs-layout/layout/root.tsx
+++ b/packages/frameworks/react-mdx/src/docs-layout/layout/root.tsx
@@ -44,6 +44,7 @@ export function Root({
   docProps,
   hideToc,
   mdxComponents,
+  navDensity = "compact",
   onDemoSettingsChange,
   onDemoStateChange,
   onPackageManagerChange,
@@ -136,6 +137,7 @@ export function Root({
       hidePageLinks,
       hideSideNav,
       mainContentElement,
+      navDensity,
       navItems,
       pageExport,
       pageFrontmatter: pageData?.data ?? {},
@@ -149,6 +151,7 @@ export function Root({
   }, [
     exports,
     hideToc,
+    navDensity,
     mainContentElement,
     navItems,
     pageDocProps,
@@ -156,7 +159,10 @@ export function Root({
     pathname,
   ])
 
-  const mergedProps = mergeProps({className: "qui-docs__root"}, props)
+  const mergedProps = mergeProps(
+    {className: "qui-docs__root", "data-nav-density": navDensity},
+    props,
+  )
 
   return (
     <MdxDocsProvider value={mdxDocsContextValue}>

--- a/packages/frameworks/react-mdx/src/docs-layout/layout/sidebar.tsx
+++ b/packages/frameworks/react-mdx/src/docs-layout/layout/sidebar.tsx
@@ -62,7 +62,7 @@ export function Sidebar({
   ...props
 }: SidebarProps): ReactElement {
   const ref = useRef<HTMLDivElement | null>(null)
-  const {navItems, pathname} = useMdxDocsLayoutContext()
+  const {navDensity, navItems, pathname} = useMdxDocsLayoutContext()
   const {renderLink: RenderLink} = useMdxDocsContext()
 
   const initialCollection = useMemo(
@@ -213,7 +213,7 @@ export function Sidebar({
   }, [scrollIntoView])
 
   const mergedProps = mergeProps(
-    {className: "qui-docs-sidebar__root", ref},
+    {className: "qui-docs-sidebar__root", "data-nav-density": navDensity, ref},
     props,
   )
 

--- a/packages/frameworks/react-mdx/src/docs-layout/layout/use-mdx-docs-layout.ts
+++ b/packages/frameworks/react-mdx/src/docs-layout/layout/use-mdx-docs-layout.ts
@@ -17,10 +17,13 @@ import type {
 } from "@qualcomm-ui/mdx-common"
 import type {PropsContextValue} from "@qualcomm-ui/react-mdx/typedoc"
 
+import type {NavDensity} from "../types"
+
 export interface MdxDocsLayoutContextState {
   hidePageLinks: boolean
   hideSideNav: boolean
   mainContentElement: HTMLElement | null
+  navDensity: NavDensity
   navItems: NavItem[]
   pageExport: boolean | KnowledgePageData | undefined
   pageFrontmatter: Record<string, unknown>

--- a/packages/frameworks/react-mdx/src/docs-layout/types.ts
+++ b/packages/frameworks/react-mdx/src/docs-layout/types.ts
@@ -21,16 +21,11 @@ export type TocHighlightStrategy = "nearest" | "viewport"
 
 /**
  * The function used to render the application's clientside link component.
- *
- * @public
  */
 export type RenderLink = (
   props: HTMLAttributes<HTMLAnchorElement> & {href: string},
 ) => ReactNode
 
-/**
- * @public
- */
 export interface DocPropsSettings {
   /**
    * URL for the changelog, used by the `@since` tags.
@@ -38,9 +33,8 @@ export interface DocPropsSettings {
   changelogUrl?: string
 }
 
-/**
- * @public
- */
+export type NavDensity = "compact" | "comfy"
+
 export interface DocsLayoutSettings extends Pick<
   MdxDocsContextValue,
   "demoSettings" | "packageManager" | "ssrUserAgent"
@@ -80,6 +74,16 @@ export interface DocsLayoutSettings extends Pick<
    * @inheritDoc
    */
   mdxComponents?: ReturnType<typeof useMDXComponents>
+
+  /**
+   * Governs sidebar nav item padding and size.
+   *
+   * @option `compact`: sidebar nav items render with reduced padding.
+   * @option 'comfy': sidebar nav items render with increased padding.
+   *
+   * @default 'compact'
+   */
+  navDensity?: NavDensity
 
   /**
    * Function fired when the demo settings change.

--- a/packages/frameworks/react-swagger/package.json
+++ b/packages/frameworks/react-swagger/package.json
@@ -48,7 +48,7 @@
     "@qualcomm-ui/qds-core": "workspace:^1.26.1",
     "@qualcomm-ui/react": "workspace:^1.20.3",
     "@qualcomm-ui/react-core": "workspace:^1.4.3",
-    "@qualcomm-ui/react-mdx": "workspace:^2.5.0",
+    "@qualcomm-ui/react-mdx": "workspace:^2.6.0",
     "@qualcomm-ui/react-test-utils": "workspace:^1.0.1",
     "@qualcomm-ui/tsconfig": "catalog:",
     "@qualcomm-ui/utils": "workspace:^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4184,7 +4184,7 @@ importers:
         specifier: workspace:^1.4.3
         version: link:../react-core
       '@qualcomm-ui/react-mdx':
-        specifier: workspace:^2.5.0
+        specifier: workspace:^2.6.0
         version: link:../react-mdx
       '@qualcomm-ui/react-test-utils':
         specifier: workspace:^1.0.1
@@ -22247,7 +22247,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.9.2)(@vitest/browser-playwright@4.1.2)(@vitest/ui@4.1.2)(jsdom@24.1.3)(vite@8.0.7(@types/node@24.9.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass-embedded@1.93.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.2(@types/node@24.10.1)(@vitest/browser-playwright@4.1.2)(@vitest/ui@4.1.2)(jsdom@24.1.3)(vite@8.0.7(@types/node@24.10.1)(esbuild@0.27.3)(jiti@2.6.1)(less@4.4.2)(sass-embedded@1.93.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.2':
     dependencies:


### PR DESCRIPTION
# Release Notes

## @qualcomm-ui/react-mdx — 2.6.0 (Apr 28th, 2026)

### Features

- [docs-layout]: add NavDensity type and prop, defaults to "compact" ([4cd65b5](https://github.com/qualcomm/qualcomm-ui/commit/4cd65b5))
- [sidebar]: integrate navDensity from context ([9636533](https://github.com/qualcomm/qualcomm-ui/commit/9636533))
