### PR TITLE
Update QUI-Docs Principles Page Types

### DIFF
--- a/packages/docs/qui-docs/src/routes/authoring+/principles.mdx
+++ b/packages/docs/qui-docs/src/routes/authoring+/principles.mdx
@@ -11,18 +11,14 @@ These guidelines cover the principles behind effective documentation. The detail
 
 ## Effective documentation
 
-A good page answers the reader's next practical question:
+Effective documentation answers the reader's next practical question. Across page types, that usually means:
 
-- What can I do with this feature?
-- When should I use it?
-- What access, setup, or data do I need first?
-- What exact steps or calls complete the task?
-- What changes after I do it?
-- How do I know it worked?
-- What can fail, and how do I fix it?
-- Where do I go next?
+- What is this and when do I use it?
+- What do I need to know or have before I start?
+- What are the exact steps, shape, or answer?
+- How do I know it worked, and what can go wrong?
 
-If the reader cannot answer those questions after reading, the page is not done.
+If the reader cannot answer those after reading, the page is not done.
 
 ## Pick a page type before writing
 
@@ -30,16 +26,12 @@ Every page is one of these. If a page does not fit one type cleanly, split it.
 
 <div className="page-type-table-prev-element"></div>
 
-| Page Type | Examples |
+| Type | Use it for |
 | --- | --- |
-| **Task Guide:** complete one concrete action. | - *Submit a job* <br /> - *Re-run a failed task run* |
-| **Workflow Guide:** move through multiple pages, tools, or systems to finish real work. | - *Prepare a host* <br /> - *Install Launcher* <br /> - *Run a test* <br /> - *Collect logs* |
-| **Capability Reference:** explain what a feature controls and how its fields, actions, states, and side effects work. | - *Build copy support API behavior* <br /> - *Resource pool fields* |
-| **Troubleshooting Guide:** start from a symptom or error and give checks, fixes, and escalation guidance. | - *Job stays queued* <br /> - *Device is unavailable* |
-| **Concept Page:** build the mental model a reader needs before following tasks. | - *Taxonomy and access control* <br /> - *Task runs and verdict impact* |
-| **Field or State Reference:** define dense columns, statuses, filters, fields, or actions. | - *Job report columns* <br /> - *Task run statuses* |
-| **Recipe Collection:** short, repeatable operations that do not need full workflow treatment. | - *Re-run a failed test case* <br /> - *Download logs for a job* |
-| **Decision Guide:** choose between valid options and understand the tradeoffs. | - *Launcher vs. Axiom Cloud vs. API* |
+| **How-to** | Walking a reader through an action — one step, many steps, or a short repeatable recipe. Examples: *submit a job*, *re-run a failed task run*, *prepare a host*, *install Launcher*. |
+| **Concept** | Building the mental model a reader needs before following tasks. Examples: *what is a taxonomy*, *how utilization is calculated*, *what is a coverage plan*. |
+| **API Guide** | Documenting an API surface — endpoints, parameters, request/response shapes, component props, fields, and states. |
+| **FAQ** | Answering questions readers ask repeatedly — errors, symptoms, edge cases, and "why does it work this way." |
 
 ## Structure pages around reader value
 
@@ -63,7 +55,7 @@ The docs site automatically builds a table of contents from H2-H4 headings. Do n
 
 ## Screenshots support, they don't replace
 
-Screenshots confirm a state, clarify a dense table, or show a non-obvious control location. They are not the documentation. Every screenshot needs nearby text explaining why it matters. If removing the screenshots leaves no useful documentation, the page is not developer documentation: rewrite it as a task, workflow, capability, or troubleshooting guide.
+Screenshots confirm a state, clarify a dense table, or show a non-obvious control location. They are not the documentation. Every screenshot needs nearby text explaining why it matters. If removing the screenshots leaves no useful documentation, the page is not developer documentation: rewrite it as a how-to, concept, API guide, or FAQ.
 
 ## Plain, direct writing
 

--- a/packages/docs/qui-docs/src/routes/authoring+/rules.mdx
+++ b/packages/docs/qui-docs/src/routes/authoring+/rules.mdx
@@ -261,7 +261,7 @@ If generated reference material is large, put the usage path first and move the 
 
 A reviewer rejects the page when:
 
-- It is only a screen tour (names a UI page, shows screenshots, explains obvious controls, and teaches no task, workflow, capability, troubleshooting path, concept, field/state set, recipe, or decision).
+- It is only a screen tour (names a UI page, shows screenshots, explains obvious controls, and teaches no how-to, concept, API behavior, or FAQ answer).
 - It does not name its page type — the first paragraph opens with `This page contains...` or `The below...`.
 - It hides prerequisites, uses screenshots as the main content, includes placeholder examples, duplicates another page, or links to stale content.
 - A new developer could not complete the documented work without asking the author for context.
@@ -291,7 +291,7 @@ Before opening the PR, confirm each item:
 - Frontmatter has `title` and H1 is `# {frontmatter.title}`.
 - No duplicate page exists under another route.
 - Page explains side effects, permissions, and failure modes when relevant.
-- Page is short enough to maintain, or has been split by task, workflow, capability, or reference area.
+- Page is short enough to maintain, or has been split by how-to, concept, or API area.
 
 ## Agentic Workflows
 

--- a/plugins/qui-docs/.claude-plugin/plugin.json
+++ b/plugins/qui-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qui-docs",
   "description": "QUI Docs workflows for documentation contributors.",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": {
     "name": "Qualcomm UI Maintainers",
     "url": "https://github.com/qualcomm/qualcomm-ui"

--- a/plugins/qui-docs/.codex-plugin/plugin.json
+++ b/plugins/qui-docs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qui-docs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "QUI Docs workflows for documentation contributors.",
   "author": {
     "name": "Qualcomm UI Maintainers",

--- a/plugins/qui-docs/references/principles.md
+++ b/plugins/qui-docs/references/principles.md
@@ -2,31 +2,23 @@
 
 ## Effective Documentation
 
-A good page answers the reader's next practical question:
+Effective documentation answers the reader's next practical question. Across page types, that usually means:
 
-- What can I do with this feature?
-- When should I use it?
-- What access, setup, or data do I need first?
-- What exact steps or calls complete the task?
-- What changes after I do it?
-- How do I know it worked?
-- What can fail, and how do I fix it?
-- Where do I go next?
+- What is this and when do I use it?
+- What do I need to know or have before I start?
+- What are the exact steps, shape, or answer?
+- How do I know it worked, and what can go wrong?
 
-If the reader cannot answer those questions after reading, the page is not done.
+If the reader cannot answer those after reading, the page is not done.
 
 ## Page Types
 
 Every page has one primary type. Split the page if it does not fit one type cleanly.
 
-- **Task Guide**: complete one concrete action.
-- **Workflow Guide**: move through multiple pages, tools, or systems to finish real work.
-- **Capability Reference**: explain what a feature controls and how fields, actions, states, and side effects work.
-- **Troubleshooting Guide**: start from a symptom or error and give checks, fixes, and escalation guidance.
-- **Concept Page**: build the mental model a reader needs before following tasks.
-- **Field or State Reference**: define dense columns, statuses, filters, fields, or actions.
-- **Recipe Collection**: short, repeatable operations that do not need full workflow treatment.
-- **Decision Guide**: choose between valid options and understand tradeoffs.
+- **How-to**: walk a reader through an action — one step, many steps, or a short repeatable recipe. Examples: submit a job, re-run a failed task run, prepare a host, install Launcher.
+- **Concept**: build the mental model a reader needs before following tasks. Examples: what is a taxonomy, how utilization is calculated, what is a coverage plan.
+- **API Guide**: document an API surface — endpoints, parameters, request/response shapes, component props, fields, and states.
+- **FAQ**: answer questions readers ask repeatedly — errors, symptoms, edge cases, and "why does it work this way."
 
 ## Page Value
 
@@ -44,7 +36,7 @@ Avoid manual table-of-contents or summary sections that duplicate the H2-H4 head
 
 Screenshots support the text. They do not replace it. Use screenshots to confirm a state, clarify a dense table, or show a non-obvious control location.
 
-Every screenshot needs nearby text explaining why it matters. If removing screenshots leaves no useful documentation, rewrite the page as a task, workflow, capability, troubleshooting, concept, field/state, recipe, or decision page.
+Every screenshot needs nearby text explaining why it matters. If removing screenshots leaves no useful documentation, rewrite the page as a how-to, concept, API guide, or FAQ.
 
 ## Writing
 

--- a/plugins/qui-docs/references/rules.md
+++ b/plugins/qui-docs/references/rules.md
@@ -194,4 +194,4 @@ Approve a page when a new developer can complete the documented work without ask
 - Frontmatter has `title` and H1 is `# {frontmatter.title}`.
 - No duplicate page exists under another route.
 - Page explains side effects, permissions, and failure modes when relevant.
-- Page is short enough to maintain or has been split by task, workflow, capability, or reference area.
+- Page is short enough to maintain or has been split by how-to, concept, or API area.


### PR DESCRIPTION
Simplifies the Documentation Page Types down to 4 types

- How-to
- Concept
- API Guide
- FAQ

Rest of the updates are to update rules etc based on this new list