### PR TITLE
Update contributing guide with GPG, SSH, and Troubleshooting sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,28 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 ## Troubleshooting
 
+### GPG signing fails with "Inappropriate ioctl for device"
+
+This shows up in terminal-only environments (Linux, macOS, WSL, Git Bash) when GPG can't open a passphrase prompt because `GPG_TTY` isn't set. The full error looks like:
+
+```
+gpg: signing failed: Inappropriate ioctl for device
+```
+
+Quick fix in the current shell:
+
+```bash
+export GPG_TTY=$(tty)
+```
+
+To make it permanent, add it to your shell profile (e.g. `~/.bashrc` or `~/.zshrc`):
+
+```bash
+echo 'export GPG_TTY=$(tty)' >> ~/.bashrc
+```
+
+If you see other signing failures on Windows, see GitHub's [Troubleshooting commit signature verification](https://docs.github.com/en/authentication/troubleshooting-commit-signature-verification/).
+
 ### Adding GPG signatures to commits you already pushed
 
 If your existing commits show as **Unverified** on GitHub, re-sign them with a rebase:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,76 @@ Your help is essential for keeping this project great and for making it better.
 
 In general, contributors should develop on branches based off of `main` and pull requests should be made against `main`.
 
+## First-time setup
+
+You'll only need to do these once per machine.
+
+### SSH key for GitHub
+
+We recommend SSH over HTTPS for public repos.
+
+1. Generate a key (skip if you already have one):
+
+    ```bash
+    ssh-keygen -t ed25519 -C "your-email@example.com"
+    ```
+
+2. Copy the public key and add it on GitHub at **Settings → SSH and GPG keys → New SSH key** (key type **Authentication Key**):
+
+    ```bash
+    cat ~/.ssh/id_ed25519.pub
+    ```
+
+3. Verify:
+
+    ```bash
+    ssh -T git@github.com
+    ```
+
+### GPG signing for verified commits
+
+Signing your commits with GPG gets you the **Verified** badge on GitHub.
+
+1. Generate a key:
+
+    ```bash
+    gpg --full-generate-key
+    ```
+
+    Recommended answers:
+    - **Kind of key:** option `9` (ECC and ECC). Fall back to `1` (RSA and RSA) at 4096 bits if `9` isn't offered.
+    - **Curve:** option `1` (Curve 25519).
+    - **Expiration:** `2y` (extendable later via `gpg --edit-key <KEY_ID>` → `expire`).
+    - **Email:** must match `git config user.email`. GitHub matches on this for the **Verified** badge.
+    - **Comment:** leave blank.
+
+2. Find your key ID and add the public key to GitHub at **Settings → SSH and GPG keys → New GPG key**:
+
+    ```bash
+    gpg --list-secret-keys --keyid-format=long
+    ```
+
+    Look for a line like:
+
+    ```
+    sec   ed25519/ABC123DEF4567890 2026-05-15 [SC] [expires: 2028-05-14]
+    ```
+
+    The part after the `/` (here, `ABC123DEF4567890`) is your `<KEY_ID>`. Then export the public key and paste the entire output (including the `-----BEGIN-----` and `-----END-----` lines) into GitHub:
+
+    ```bash
+    gpg --armor --export <KEY_ID>
+    ```
+
+3. Configure git to use your key. Follow GitHub's [Telling Git about your signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key) guide, which has OS-specific steps for Linux, macOS, and Windows.
+
 ## Submitting a pull request
 
 1. Please read our [code of conduct](CODE-OF-CONDUCT.md) and [license](LICENSE.txt).
 1. [Fork](https://github.com/qualcomm/qualcomm-ui/fork) and clone the repository.
 
     ```bash
-    git clone https://github.com/<username>/qualcomm-ui.git
+    git clone git@github.com:<username>/qualcomm-ui.git
     ```
 
 1. Create a new branch based on `main`:
@@ -26,14 +89,14 @@ In general, contributors should develop on branches based off of `main` and pull
 1. Create an upstream `remote` to make it easier to keep your branches up-to-date:
 
     ```bash
-    git remote add upstream https://github.com/qualcomm/qualcomm-ui.git
+    git remote add upstream git@github.com:qualcomm/qualcomm-ui.git
     ```
 
 1. Make your changes, add tests, and make sure the tests still pass.
-1. Commit your changes using the [DCO](https://developercertificate.org/). You can attest to the DCO by commiting with the **-s** or **--signoff** options or manually adding the "Signed-off-by":
+1. Commit your changes. Every commit must include a [DCO](https://developercertificate.org/) sign-off and a GPG signature. Use `-s` for sign-off and `-S` for the signature:
 
     ```bash
-    git commit -s -m "Really useful commit message"`
+    git commit -s -S -m "Really useful commit message"
     ```
 
 1. After committing your changes on the topic branch, sync it with the upstream branch:
@@ -74,3 +137,41 @@ Here are a few things you can do that will increase the likelihood of your pull 
   If you want to make multiple independent changes, please consider submitting them as separate pull requests.
 - Write a [good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - It's a good idea to arrange a discussion with other developers to ensure there is consensus on large features, architecture changes, and other core code changes. PR reviews will go much faster when there are no surprises.
+
+## Troubleshooting
+
+### Adding GPG signatures to commits you already pushed
+
+If your existing commits show as **Unverified** on GitHub, re-sign them with a rebase:
+
+```bash
+git rebase HEAD~<N> --exec 'git commit --amend --no-edit -S'
+git push --force-with-lease origin <my-branch-name>
+```
+
+…where `<N>` is the number of commits you want to re-sign. You'll be prompted for your GPG passphrase once per commit.
+
+> **Heads up:** force-pushing rewrites history. Only do this on branches no one else is working from.
+
+### Recovering unsigned commits
+
+If the DCO bot has blocked your PR because earlier commits are missing `Signed-off-by`, and you're the only person on the branch:
+
+```bash
+git rebase HEAD~<N> --signoff --exec 'git commit --amend --no-edit -S'
+git push --force-with-lease origin <my-branch-name>
+```
+
+…where `<N>` is the number of unsigned commits. The `--exec` step also re-signs each commit with GPG.
+
+If your range contains an empty commit (for example one made just to retrigger CI), drop it first. `git commit --amend` refuses to amend an empty commit:
+
+```bash
+git reset --hard HEAD~1                          # drop the empty commit
+git commit --amend --signoff --no-edit -S        # sign-off + GPG-sign the real commit
+git push --force-with-lease origin <my-branch-name>
+```
+
+The force-push retriggers CI on its own.
+
+> **Heads up:** force-pushing rewrites history. Only do this on branches no one else is working from.


### PR DESCRIPTION
Updates the contributing guide with the following

- how to generate GPG key
- using SSH over HTTPS
- troubleshooting guide if you have already pushed up commits without signing