### PR TITLE
fix(angular-core/use-id): hash collision

### DIFF
--- a/.changeset/rare-bars-fry.md
+++ b/.changeset/rare-bars-fry.md
@@ -1,0 +1,7 @@
+---
+"@qualcomm-ui/angular-core": patch
+---
+
+fix(angular-core/use-id): hash collision
+
+commit: dd06a6e

--- a/packages/frameworks/angular-core/src/common/use-id.ts
+++ b/packages/frameworks/angular-core/src/common/use-id.ts
@@ -1,26 +1,11 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-const ids: Record<string, number> = {}
+let counter = 0
 
-export function useId(component: object, id: string | undefined | null) {
+export function useId(_component: object, id: string | undefined | null) {
   if (id) {
     return id
   }
-  const name = component.constructor.name
-  if (!ids[name]) {
-    ids[name] = 1
-  }
-  const nextId = ids[name]++
-  return `«auto::${hashCode(`${name}${nextId.toString(32)}`).toString(32)}»`
-}
-
-function hashCode(str: string): number {
-  let hash = 0
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i)
-    hash = (hash << 5) - hash + char
-    hash = hash & hash // Convert to 32-bit integer
-  }
-  return Math.abs(hash)
+  return `«auto::${(++counter).toString(32)}»`
 }


### PR DESCRIPTION
stumbled on this by accident while updating Tabs for #248: the temporary demo I used to display several tabs variants made the indicator in other demos malfunction.

turns out the hashing code, in our case used to create tab button ids that the indicator uses to position itself, produces collisions¹, so rendering a page with lots of tabs generated multiple identical ids.

this PR removes the unnecessary hashing and keeps a sequential counter. note that the `component` argument is now unused but kept, as the function is exposed as a public API. LMK if you're ok to drop it and refactor the call sites.

---

¹ precisely: starting at 55 (`1n` in base 32), every 32 counter steps a group of 9 colliding pairs (41 apart) is produced. i.e., `1n`/`30`, `1o`/`31`, (+7 other) then `2n`/`40`, `2o`/`41`, (+7 other), etc.