### PR TITLE
Add tailwind plugin package support metadata

### DIFF
--- a/packages/common/tailwind-plugin/package.json
+++ b/packages/common/tailwind-plugin/package.json
@@ -5,6 +5,10 @@
   "author": "Ryan Bower",
   "license": "BSD-3-Clause-Clear",
   "repository": "https://github.com/qualcomm/qualcomm-ui",
+  "homepage": "https://github.com/qualcomm/qualcomm-ui#readme",
+  "bugs": {
+    "url": "https://github.com/qualcomm/qualcomm-ui/issues"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Add standard npm package support metadata to `@qualcomm-ui/tailwind-plugin`:

- `homepage` points to the project README
- `bugs.url` points to the GitHub issue tracker

## Verification

```bash
node - <<'NODE'
const fs = require('fs')
const pkg = JSON.parse(fs.readFileSync('packages/common/tailwind-plugin/package.json', 'utf8'))
if (pkg.homepage !== 'https://github.com/qualcomm/qualcomm-ui#readme') process.exit(1)
if (pkg.bugs?.url !== 'https://github.com/qualcomm/qualcomm-ui/issues') process.exit(1)
console.log('metadata ok')
NODE
npm pack --dry-run --ignore-scripts ./packages/common/tailwind-plugin
git diff --check
```

Related metadata bounty: charles-openclaw/charles-microbounties#651