### PR TITLE
Add support metadata to Tailwind plugin package

### DIFF
--- a/packages/common/tailwind-plugin/package.json
+++ b/packages/common/tailwind-plugin/package.json
@@ -62,5 +62,9 @@
   },
   "peerDependencies": {
     "tailwindcss": ">=4"
+  },
+  "homepage": "https://github.com/qualcomm/qualcomm-ui#readme",
+  "bugs": {
+    "url": "https://github.com/qualcomm/qualcomm-ui/issues"
   }
 }


### PR DESCRIPTION
Adds npm support metadata for `@qualcomm-ui/tailwind-plugin`.

The package already publishes repository and license metadata, but does not expose `homepage` or `bugs.url` in the published manifest. This adds the repo README and issue tracker URLs without changing runtime code.

Verification:
- Parsed `packages/common/tailwind-plugin/package.json` and confirmed `homepage` and `bugs.url` are present.
