### PR TITLE
chore: pre-bundle dynamic deps used in react-ssr

### DIFF
--- a/packages/debug-apps/react-ssr/vite.config.ts
+++ b/packages/debug-apps/react-ssr/vite.config.ts
@@ -15,6 +15,18 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  /**
+   * Pre-bundle deps the static scanner can't see (react/compiler-runtime is
+   * injected by babel), so a late re-optimization can't crash the page mid-load.
+   */
+  optimizeDeps: {
+    include: [
+      "react/compiler-runtime",
+      "@tanstack/react-query",
+      "@floating-ui/dom",
+      "lodash-es",
+    ],
+  },
   plugins: [
     tailwindcss(),
     mdx({


### PR DESCRIPTION
<img width="815" height="142" alt="image" src="https://github.com/user-attachments/assets/e577bccd-2d9e-4e9e-9b11-b677b0beb8c2" />
the late package discovery apparently creates stale references:
<img width="687" height="46" alt="image" src="https://github.com/user-attachments/assets/db4c3db3-9159-44f6-b835-426af47f8d91" />
preloading them fixes that